### PR TITLE
build: fix nodejs version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - 'stable'
+  - 14
 branches:
   only:
     - 'master'


### PR DESCRIPTION
This PR fixes the Node.js version to v14x in order to avoid breaking changes that fail the CI.